### PR TITLE
Rename docker image to proxy-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 STOPSIGNAL SIGQUIT
 
-WORKDIR /static-server
+WORKDIR /proxy-server
 
 COPY ./package.json .
 RUN npm install && npm install gulp -g

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@
 > 在浏览器中打开 http://localhost:8080/     
 > 我设置了自动刷新功能，更改代码保存之后页面就会自动刷新了，方便开发。若出现未自动刷新的情况，可手动刷新。若是向项目中添加了新文件或对文件重命名等非更改代码操作，需要重新执行 gulp clean 和 gulp 指令。   
 
-> 使用 Docker 运行：   
-> docker build -t static-server .    
-> docker run --name static-server -p 8080:80 -d static-server   
+> 构建 docker 镜像：   
+> docker build -t proxy-server .
 
 ## 目录结构
  -  layouts/：各页面内容部分，放置各.jade文件   


### PR DESCRIPTION
为了与集成测试统一，修改 docker 镜像名为 `proxy-server`。